### PR TITLE
fix description

### DIFF
--- a/modules/10-basics/60-structs/description.ru.yml
+++ b/modules/10-basics/60-structs/description.ru.yml
@@ -126,7 +126,7 @@ instructions: |
 
   ```go
   type UserCreateRequest struct {
-    FirstName string // не может быть пустым; не может содержать больше одного слова
+    FirstName string // не может быть пустым; не может содержать пробелы
     Age int // не может быть 0 или отрицательным; не может быть больше 150
   }
   ```


### PR DESCRIPTION
В тестах есть следующая проверка
```
a.Equal("invalid request", Validate(UserCreateRequest{
		FirstName: " Henry",
		Age:       15,
	}))
```
По факту в FirstName - одно слово, но с пробелом 
И в решении учителя проверяется количество пробелов (они могут быть в начале или в конце, а не только разделять слова)

Для однозначности лучше одно из двух:
1) Поправить текст задания - что и сделано в данном PR
2) Поправить решение учителя и тест - проверять несколько слов