### PR TITLE
(30/25) improve solution

### DIFF
--- a/modules/30-strings/25-strings-standard-pkg/description.ru.yml
+++ b/modules/30-strings/25-strings-standard-pkg/description.ru.yml
@@ -44,6 +44,8 @@ instructions: |
   latinLetters("привет world!") // "world"
   ```
 
+  Для решения задачи можно использовать метод `Is()` и одну из переменных, соответствующую латинским символам, из модуля [unicode](https://pkg.go.dev/unicode).
+
 tips:
   - |
     [Go standard package — strings](https://pkg.go.dev/strings)

--- a/modules/30-strings/25-strings-standard-pkg/description.ru.yml
+++ b/modules/30-strings/25-strings-standard-pkg/description.ru.yml
@@ -37,14 +37,13 @@ theory: |
 
 
 instructions: |
+  В пакете unicode есть [функция `unicode.Is(unicode.Latin, rune)`](https://pkg.go.dev/unicode#Is), которая проверяет, что руна является латинским символом или нет.
 
   Реализуйте функцию `latinLetters(s string) string`, которая возвращает только латинские символы из строки `s`. Например:
 
   ```go
   latinLetters("привет world!") // "world"
   ```
-
-  Для решения задачи можно использовать метод `Is()` и одну из переменных, соответствующую латинским символам, из модуля [unicode](https://pkg.go.dev/unicode).
 
 tips:
   - |

--- a/modules/30-strings/25-strings-standard-pkg/solution.go
+++ b/modules/30-strings/25-strings-standard-pkg/solution.go
@@ -2,21 +2,19 @@ package solution
 
 import (
 	"strings"
+	"unicode"
 )
 
-// BEGIN
-
-// latinLetters returns only latin letters from the string s filtering all other chars.
+// BEGIN (write your solution here)
 func latinLetters(s string) string {
 	sb := &strings.Builder{}
 
 	for _, r := range s {
-		if (r >= 'a' && r <= 'z') || (r >= 'A' && r <= 'Z') {
+		if unicode.Is(unicode.Latin, r)  {
 			sb.WriteRune(r)
 		}
-	}
+    }
 
-	return sb.String()
+    return sb.String()
 }
-
 // END


### PR DESCRIPTION
Модуль unicode изучался уроком ранее. В данном случае выглядит логичным использование метода `Is()` в комбинации с переменной `Latin`:
```go
unicode.Is(unicode.Latin, rune)
```
Вместо предиката: 
```go
(r >= 'a' && r <= 'z') || (r >= 'A' && r <= 'Z')
```
Так как нам нужно получить только латинские символы в результирующей строке.