### PR TITLE
Fix solution

### DIFF
--- a/modules/10-basics/25-variables/solution.go
+++ b/modules/10-basics/25-variables/solution.go
@@ -6,6 +6,6 @@ func main() {
 	// BEGIN
 	firstName := "John"
 	lastName := "Smith"
-	fmt.Println(firstName, lastName)
+	fmt.Println(firstName + " " + lastName)
 	// END
 }


### PR DESCRIPTION
The previous solution returned "JonhSmith"—incorrect because the exercise needs to return "Jonh Smith". I used string concatenation rather than string interpolation because, at that level, people can understand this solution.