### PR TITLE
Update solution_test.go

### DIFF
--- a/modules/20-array-slice-map/10-array/solution_test.go
+++ b/modules/20-array-slice-map/10-array/solution_test.go
@@ -12,6 +12,8 @@ func TestSafeWrite(t *testing.T) {
 	a.Equal([5]int{}, SafeWrite([5]int{}, -10, 10))
 	a.Equal([5]int{}, SafeWrite([5]int{}, 10, 10))
 	a.Equal([5]int{}, SafeWrite([5]int{}, 20, 10))
+	a.Equal([5]int{}, SafeWrite([5]int{}, 5, 10))
+	a.Equal([5]int{10, 2, 10, 4, 5}, SafeWrite([5]int{1, 2, 3, 4, 5}, 0, 10))
 	a.Equal([5]int{1, 2, 10, 4, 5}, SafeWrite([5]int{1, 2, 3, 4, 5}, 2, 10))
 	a.Equal([5]int{1, 2, 3, 4, 22}, SafeWrite([5]int{1, 2, 3, 4, 5}, 4, 22))
 }


### PR DESCRIPTION
В существующих тестах не проверяются граничные условия, из-за чего проходит неверное решение, например:

`if i < len(nums) && i > 0 `