### PR TITLE
fix: errors handling assignment example usage

### DIFF
--- a/modules/40-func/35-errors-handling/description.ru.yml
+++ b/modules/40-func/35-errors-handling/description.ru.yml
@@ -148,8 +148,8 @@ instructions: |
   Реализуйте функцию `GetErrorMsg(err error) string`, которая возвращает текст ошибки, если она критичная. В случае неизвестной ошибки возвращается строка *unknown error*:
 
   ```go
-  GetErrorMsg(errors.New("bad connection")) // "bad connection"
-  GetErrorMsg(errors.New("bad request")) // "bad request"
+  GetErrorMsg(errBadConnection) // "bad connection"
+  GetErrorMsg(errBadRequest) // "bad request"
   GetErrorMsg(nonCriticalError{}) // ""
   GetErrorMsg(errors.New("random error")) // "unknown error"
   ```


### PR DESCRIPTION
Current example usage won't work because of how `errors.Is()` operates. Creation of new error using `errors.New()` with the same text won't match previously created errors (`errBadConnection` and `errBadRequest`)

Test cases use correct version: 

![image](https://github.com/hexlet-basics/exercises-go/assets/33966765/928f16b2-b9a5-44d5-b3f7-9eaeaf510f24)
